### PR TITLE
Add configurable output destination for merged videos (#5)

### DIFF
--- a/main.js
+++ b/main.js
@@ -361,6 +361,28 @@ ipcMain.handle('get-output-directory', async (event, inputPath) => {
   }
 });
 
+// Select output destination folder
+ipcMain.handle('select-output-destination', async () => {
+  const result = await dialog.showOpenDialog(mainWindow, {
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Select Output Destination Folder'
+  });
+
+  if (result.canceled) {
+    return { canceled: true, path: null };
+  }
+
+  const selectedPath = result.filePaths[0];
+  
+  try {
+    // Ensure the directory exists
+    await fs.mkdir(selectedPath, { recursive: true });
+    return { canceled: false, path: selectedPath };
+  } catch (error) {
+    throw new Error(`Failed to access output directory: ${error.message}`);
+  }
+});
+
 // Open folder in Finder
 ipcMain.handle('open-folder', async (event, folderPath) => {
   const { shell } = require('electron');

--- a/preload.js
+++ b/preload.js
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getVideoDuration: (filePath) => ipcRenderer.invoke('get-video-duration', filePath),
   mergeVideos: (filePaths, outputPath) => ipcRenderer.invoke('merge-videos', filePaths, outputPath),
   getOutputDirectory: (inputPath) => ipcRenderer.invoke('get-output-directory', inputPath),
+  selectOutputDestination: () => ipcRenderer.invoke('select-output-destination'),
   openFolder: (folderPath) => ipcRenderer.invoke('open-folder', folderPath),
   checkFFmpeg: () => ipcRenderer.invoke('check-ffmpeg'),
   installPrerequisites: () => ipcRenderer.invoke('install-prerequisites'),

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -56,6 +56,22 @@
         
         <div id="previewList" class="preview-list"></div>
         
+        <div class="output-destination-section">
+          <label class="output-destination-label">Output Destination:</label>
+          <div class="output-destination-controls">
+            <div id="outputDestinationDisplay" class="output-destination-display">
+              <span id="outputDestinationPath" class="output-destination-path">Using default location (merged_videos subfolder)</span>
+            </div>
+            <button id="selectOutputDestinationBtn" class="btn btn-secondary btn-small">
+              <span class="btn-icon">📁</span>
+              Choose Folder
+            </button>
+            <button id="useDefaultDestinationBtn" class="btn btn-text btn-small" style="display: none;">
+              Use Default
+            </button>
+          </div>
+        </div>
+        
         <div class="preview-actions">
           <button id="backBtn" class="btn btn-secondary">
             <span class="btn-icon">←</span>

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -415,6 +415,71 @@ body {
   border-radius: 4px;
 }
 
+/* Output Destination Section */
+.output-destination-section {
+  margin: 20px 0;
+  padding: 16px;
+  background: #f8f9fa;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+.output-destination-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1d1d1f;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.output-destination-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.output-destination-display {
+  flex: 1;
+  min-width: 200px;
+}
+
+.output-destination-path {
+  font-size: 13px;
+  color: #86868b;
+  word-break: break-all;
+  display: inline-block;
+  padding: 8px 12px;
+  background: #ffffff;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  min-height: 20px;
+}
+
+.output-destination-path.custom-path {
+  color: #1d1d1f;
+  font-weight: 500;
+}
+
+.btn-small {
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.btn-text {
+  background: transparent;
+  border: none;
+  color: #007aff;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.btn-text:hover {
+  color: #0051d5;
+}
+
 .preview-actions {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
This PR adds the ability to configure the output destination for merged videos.

## Changes
- Added UI element in preview screen to select output destination folder
- Added IPC handler for selecting output directory via folder picker dialog  
- Updated merge logic to use custom destination if selected, otherwise defaults to merged_videos subfolder
- Added option to switch back to default location
- Styled output destination section with clear visual feedback

## How it works
- By default, videos are saved to a `merged_videos` subfolder in the input directory
- Users can click "Choose Folder" to select a custom destination
- The selected path is displayed with an option to revert to default

Closes #5